### PR TITLE
Feature proposal: multi-select menu for custom script choices

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -155,4 +155,107 @@ _install_scripts() {
     fi
 }
 
+function multiselect {
+    # helpers for console print format and control
+    ESC=$( printf "\033")
+    cursor_blink_on()   { printf "$ESC[?25h"; }
+    cursor_blink_off()  { printf "$ESC[?25l"; }
+    cursor_to()         { printf "$ESC[$1;${2:-1}H"; }
+    print_inactive()    { printf "$2   $1 "; }
+    print_active()      { printf "$2  $ESC[7m $1 $ESC[27m"; }
+    get_cursor_row()    { IFS=';' read -sdR -p $'\E[6n' ROW COL; echo "${ROW#*[}"; }
+
+    local return_value=$1
+    local -n options=$2
+    local -n defaults=$3
+    # if [ ${#defaults[@]} -eq 0 ]; then
+    #     defaults=()
+    # fi
+
+    local selected=()
+    for ((i=0; i<${#options[@]}; i++)); do
+        if [[ -v "defaults[i]" ]] ; then
+            if [[ ${defaults[i]} = "false" ]]; then
+                selected+=("false")
+            else
+                selected+=("true")
+            fi
+        else
+            selected+=("true")
+        fi
+        printf "\n"
+    done
+
+    # determine current screen position for overwriting the options
+    local lastrow=`get_cursor_row`
+    local startrow=$(($lastrow - ${#options[@]}))
+
+    # ensure cursor and input echoing back on upon a ctrl+c during read -s
+    trap "cursor_blink_on; stty echo; printf '\n'; exit" 2
+    cursor_blink_off
+
+    key_input() {
+        local key
+        IFS= read -rsn1 key 2>/dev/null >&2
+        if [[ $key = ""      ]]; then echo enter; fi;
+        if [[ $key = $'\x20' ]]; then echo space; fi;
+        if [[ $key = "k" ]]; then echo up; fi;
+        if [[ $key = "j" ]]; then echo down; fi;
+        if [[ $key = $'\x1b' ]]; then
+            read -rsn2 key
+            if [[ $key = [A || $key = k ]]; then echo up;    fi;
+            if [[ $key = [B || $key = j ]]; then echo down;  fi;
+        fi 
+    }
+
+    toggle_option() {
+        local option=$1
+        if [[ ${selected[option]} == true ]]; then
+            selected[option]=false
+        else
+            selected[option]=true
+        fi
+    }
+
+    print_options() {
+        # print options by overwriting the last lines
+        idx=0
+        for option in "${options[@]}"; do
+            local prefix="[ ]"
+            if [[ ${selected[idx]} == true ]]; then
+              prefix="[\e[38;5;46m✔\e[0m]"
+            fi
+
+            cursor_to $(($startrow + $idx))
+            if [ $idx -eq $1 ]; then
+                print_active "$option" "$prefix"
+            else
+                print_inactive "$option" "$prefix"
+            fi
+            ((idx++))
+        done
+    }
+
+    local active=0
+    while true; do
+        print_options $active
+        # user key control
+        case $(key_input) in
+            space)  toggle_option $active;;
+            enter)  print_options -1; break;;
+            up)     ((active--));
+                    if [ $active -lt 0 ]; then active=$((${#options[@]} - 1)); fi;;
+            down)   ((active++));
+                    if [ $active -ge ${#options[@]} ]; then active=0; fi;;
+        esac
+    done
+
+    # cursor position back to normal
+    cursor_to "$lastrow"
+    printf "\n"
+    cursor_blink_on
+
+    eval "$return_value"='("${selected[@]}")'
+}
+
 _main "$@"

--- a/install.sh
+++ b/install.sh
@@ -219,7 +219,7 @@ function multiselect {
 
     # determine current screen position for overwriting the options
     local lastrow=`get_cursor_row`
-    local startrow=$(($lastrow - ${#options[@]}))
+    local startrow=$((lastrow - ${#options[@]}))
 
     # ensure cursor and input echoing back on upon a ctrl+c during read -s
     trap "cursor_blink_on; stty echo; printf '\n'; exit" 2
@@ -257,7 +257,7 @@ function multiselect {
               prefix="[\e[38;5;46m✔\e[0m]"
             fi
 
-            cursor_to $(($startrow + $idx))
+            cursor_to $((startrow + idx))
             if [ $idx -eq $1 ]; then
                 print_active "$option" "$prefix"
             else

--- a/install.sh
+++ b/install.sh
@@ -218,7 +218,8 @@ function multiselect {
     done
 
     # determine current screen position for overwriting the options
-    local lastrow=`get_cursor_row`
+    local lastrow
+    lastrow=$(get_cursor_row)
     local startrow=$((lastrow - ${#options[@]}))
 
     # ensure cursor and input echoing back on upon a ctrl+c during read -s
@@ -258,7 +259,7 @@ function multiselect {
             fi
 
             cursor_to $((startrow + idx))
-            if [ $idx -eq $1 ]; then
+            if [ $idx -eq "$1" ]; then
                 print_active "$option" "$prefix"
             else
                 print_inactive "$option" "$prefix"

--- a/install.sh
+++ b/install.sh
@@ -48,6 +48,7 @@ _main() {
     then
         echo
         echo " > Please pick the desired categories. You can find more information in README.md."
+        echo " (SPACE) to select, (UP/DOWN) to choose"
         for dirname in ./*/; do
             dirn="${dirname:2}"             # remove leading path separators (./)
             script_dirs+=("${dirn::-1}")    # remove trailing path separator (/)


### PR DESCRIPTION
Hi! As I already mentioned, I like this collection a lot. That's why I'd like to contribute this little selection menu. It provides the user with some control over which scripts should get installed.

Demo:
![image](https://github.com/cfgnunes/nautilus-scripts/assets/59444046/cf39a4fc-2fb7-42a0-84e8-f2f65de9113f)
_based on a snippet found on StackExchange (https://unix.stackexchange.com/a/673436)_

It uses the existing subfolder structure as selectable options.
**Note**: for a not entirely obvious reason I needed to change your `set -eu` instruction to `set -u`. Some function's exit code in the multi-select menu apparently is not approved by the `-e` switch.
Also, it would be probably a good idea to provide some information in `README.md` on the available scripts, explaining the subfolder choices a little bit.

Let me know what you think! :) 