### PR TITLE
perf: Remove unnecessary forking from grep|head -1

### DIFF
--- a/File encryption/GPG Import key
+++ b/File encryption/GPG Import key
@@ -30,7 +30,7 @@ _main_task() {
     local key_id=""
 
     # Get the ID from the key.
-    key_id=$(gpg --with-colons --import-options show-only --import "$input_file" | grep "^fpr" | head -1 | cut -d ':' -f 10 2>/dev/null)
+    key_id=$(gpg --with-colons --import-options show-only --import "$input_file" | grep -m1 "^fpr" | cut -d ':' -f 10 2>/dev/null)
 
     # Import the key.
     std_output=$(gpg --batch --yes --import "$input_file" 2>&1)

--- a/common-functions.sh
+++ b/common-functions.sh
@@ -1583,7 +1583,7 @@ _xdg_get_default_app() {
 
     desktop_file=$(xdg-mime query default "$mime" 2>/dev/null)
 
-    default_app=$(grep "^Exec" "/usr/share/applications/$desktop_file" | head -n1 | sed "s|Exec=||g" | cut -d " " -f 1)
+    default_app=$(grep -m1 "^Exec" "/usr/share/applications/$desktop_file" | sed "s|Exec=||g" | cut -d " " -f 1)
 
     if [[ -z "$default_app" ]]; then
         _display_error_box "Could not find the default application to open '$mime' files!"


### PR DESCRIPTION
`grep 'foo' | head -n1` is unnecessary in a world with `grep -m1`