### PR TITLE
`dnf` skip broken dependencies

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -204,7 +204,7 @@ _step_install_dependencies() {
             # Distro: Fedora.
             # Missing packages: findimagedupes, mp3val.
             sudo dnf check-update || true
-            sudo dnf -y install $common_names p7zip ImageMagick xz poppler-utils ffmpeg-free genisoimage foremost testdisk rdfind squashfs-tools
+            sudo dnf -y install $common_names p7zip ImageMagick xz poppler-utils ffmpeg-free genisoimage foremost testdisk rdfind squashfs-tools --skip-broken
         elif _command_exists "pacman"; then
             # Distro: Manjaro, Arch Linux.
             # Missing packages: findimagedupes, mp3gain, mp3val.


### PR DESCRIPTION
If you have some broken dependencies at least you can continue the installation.

The result if you have some broke dependencies is:

![image](https://github.com/user-attachments/assets/cf92f87e-67d0-4a99-8ffa-98b26662bc9a)


I tested it solving  #32 

Now with this flag the installation continued i i can use the tool