### PR TITLE
Remove non-necessary fixed options from gpg calls

### DIFF
--- a/File encryption/GPG Encrypt with password
+++ b/File encryption/GPG Encrypt with password
@@ -39,11 +39,6 @@ _main_task() {
         --yes \
         --symmetric \
         --passphrase "$TEMP_DATA_TASK" \
-        --for-your-eyes-only \
-        --s2k-count 1015808 \
-        --s2k-digest-algo SHA256 \
-        --compress-algo zlib \
-        --cipher-algo AES256 \
         --output "$output_file" \
         -- "$input_file" 2>&1)
     _check_output "$?" "$std_output" "$input_file" "$output_file" || return 1

--- a/File encryption/GPG Encrypt with password (ASCII)
+++ b/File encryption/GPG Encrypt with password (ASCII)
@@ -39,12 +39,7 @@ _main_task() {
         --yes \
         --symmetric \
         --passphrase "$TEMP_DATA_TASK" \
-        --for-your-eyes-only \
         --armor \
-        --s2k-count 1015808 \
-        --s2k-digest-algo SHA256 \
-        --compress-algo zlib \
-        --cipher-algo AES256 \
         --output "$output_file" \
         -- "$input_file" 2>&1)
     _check_output "$?" "$std_output" "$input_file" "$output_file" || return 1

--- a/File encryption/GPG Encrypt with public keys
+++ b/File encryption/GPG Encrypt with public keys
@@ -96,11 +96,6 @@ _main_task() {
         --yes \
         --encrypt \
         "${recipients[@]}" \
-        --for-your-eyes-only \
-        --s2k-count 1015808 \
-        --s2k-digest-algo SHA256 \
-        --compress-algo zlib \
-        --cipher-algo AES256 \
         --output "$output_file" \
         -- "$input_file" 2>&1)
 

--- a/File encryption/GPG Encrypt with public keys (ASCII)
+++ b/File encryption/GPG Encrypt with public keys (ASCII)
@@ -96,12 +96,7 @@ _main_task() {
         --yes \
         --encrypt \
         "${recipients[@]}" \
-        --for-your-eyes-only \
         --armor \
-        --s2k-count 1015808 \
-        --s2k-digest-algo SHA256 \
-        --compress-algo zlib \
-        --cipher-algo AES256 \
         --output "$output_file" \
         -- "$input_file" 2>&1)
 


### PR DESCRIPTION
These options can easily defined in the gnupg option file at `~/.gnupg/gpg.conf` . Setting them on the command line forces to use particular crypto settings, which can not be overwritten in the option file. This makes nautilus-scripts unusable, if the options don't fit to the users needs. So it's better to use gnupg's defaults instead.