### PR TITLE
feat: rpm-ostree installation check

### DIFF
--- a/common-functions.sh
+++ b/common-functions.sh
@@ -275,6 +275,7 @@ _check_dependencies() {
                 if command -v rpm-ostree &>/dev/null && rpm-ostree status --json | jq -r '.deployments[0].packages[]' | grep -Fxq "$par_package_check"; then
                      _display_info_box \
                          "The package '$par_package_check' is installed but you need to reboot to use it"
+                    _exit_script
                 else
                     _display_error_box \
                         "Could not install the package '$par_package_check'!"

--- a/common-functions.sh
+++ b/common-functions.sh
@@ -2380,7 +2380,7 @@ _pkg_install_packages() {
         cmd_install+="dnf -y install $packages &>/dev/null"
         ;;
     "rpm-ostree")
-        cmd_install+="rpm-ostree install --apply-live $packages &>/dev/null"
+        cmd_install+="rpm-ostree install $packages &>/dev/null"
         ;;
     "pacman")
         cmd_install+="pacman -Syy;"

--- a/common-functions.sh
+++ b/common-functions.sh
@@ -272,9 +272,14 @@ _check_dependencies() {
         for par_package_check in $packages_to_check; do
             if ! _pkg_is_package_installed \
                 "$available_pkg_manager" "$par_package_check"; then
-                _display_error_box \
-                    "Could not install the package '$par_package_check'!"
-                _exit_script
+                if command -v rpm-ostree &>/dev/null && rpm-ostree status --json | jq -r '.deployments[0].packages[]' | grep -Fxq "$par_package_check"; then
+                     _display_info_box \
+                         "The package '$par_package_check' is installed but you need to reboot to use it"
+                else
+                    _display_error_box \
+                        "Could not install the package '$par_package_check'!"
+                    _exit_script
+                fi
             fi
         done
         _display_info_box "The packages have been successfully installed!"


### PR DESCRIPTION
These are a couple small changes that I think is ideal long-term.

commit: 613e548f46bcbc7c12142c8e7b89c22ab5a8d59b
> the --apply-live subcommand adds unnecessary complexity. The removal is due to: in my testing I interrupted rpm-ostree while applying the live commit and was left with the inability to apply the overlayed packages and an OS stuck in a transient state. if you re-attempt, the packages are still layered the apply-live is broken.

Additional notes: I suppose I could try to fix '--apply-live' if it gets canceled mid-commit, but I don't think it's worth all that effort when all you need to do is reboot vs running 10 or more commands that may or may not work and you may need to reboot regardless. Removing apply-live is *probably* safer, easier, and better for code-complexity.

commit: ac5bb064ef0df2542d66f23c5f6a217d1389b0af
> This is so when rpm-ostree installs package in it's unique way, it provides useful feedback and correctly checks & states that a package is installed.

commit: 8f8b37546851b5b8d7f0a2b08af6e8c8a4788b5a
I forgot to add this, and the script tries to run commands that aren't installed.