### PR TITLE
move: applications to dedicated folder

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -807,11 +807,12 @@ _step_install_application_shortcuts() {
     local name=""
     local script_relative=""
     local submenu=""
-    local menus_dir="$INSTALL_HOME/.local/share/applications"
+    local menus_dir="$INSTALL_HOME/.local/share/applications/nautilus-scripts"
 
     _echo_info "> Creating '.desktop' files..."
 
     # Remove previously installed '.desktop' files.
+    mkdir -p "$INSTALL_HOME/.local/share/applications/nautilus-scripts"
     $SUDO_CMD rm -f -- "$menus_dir/$APP_SHORTCUT_PREFIX"*.desktop
 
     $SUDO_CMD_USER mkdir --parents "$menus_dir"


### PR DESCRIPTION
This PR might be considered slightly nit-picky but the proposed change is as follows:

`install.sh` Line 810: just moves it inside a clearly labeled folder in a similar way to the way wine creates a 'wine' folder inside applications, it still functions **exactly as intended** but it's a bit more tidy. 

They should now be inside `~/.local/share/applications/nautilus-scripts/`

On a unrelated note: Incredible work the last couple days! 🚀 Keep it up!👍